### PR TITLE
Add quotes to Run command to create new instance

### DIFF
--- a/lib/CQT.MenuButtons.ahk
+++ b/lib/CQT.MenuButtons.ahk
@@ -25,7 +25,7 @@ class MenuButtons
 	
 	New() ; TODO: Make this work for MultiTester mode
 	{
-		Run, %A_AhkPath% %A_ScriptFullPath%
+		Run, "%A_AhkPath%" "%A_ScriptFullPath%"
 	}
 	
 	Publish()


### PR DESCRIPTION
Command lines parameters need quotes for file paths with spaces.