### PR TITLE
Update Utils.ahk

### DIFF
--- a/lib/Utils.ahk
+++ b/lib/Utils.ahk
@@ -55,9 +55,9 @@ DeHashBang(Script)
 
 UrlDownloadToVar(Url)
 {
-	http := ComObjCreate("WinHttp.WinHttpRequest.5.1")
-	http.Open("GET", Url, false), http.Send()
-	return http.ResponseText
+	xhr := ComObjCreate("MSXML2.XMLHTTP")
+	xhr.Open("GET", url, false), xhr.Send()
+	return xhr.ResponseText
 }
 
 ; Helper function, to make passing in expressions resulting in function objects easier


### PR DESCRIPTION
MSXML2.XMLHTTP works correctly through a proxy whereas WinHttp.WinHttpRequest.5.1 doesn't correctly use the OS's defined proxy settings.